### PR TITLE
Hiba javitas

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,23 +4,33 @@ constexpr int N_ELEMENTS = 100;
 
 int main()
 {
-    int *b = new int[NELEMENTS];
-    std::cout << '1-100 ertekek duplazasa'
-    for (int i = 0;)
+    int *b = new int[N_ELEMENTS]; // Helyes név és szintaxis
+    std::cout << "1-100 ertekek duplazasa" << std::endl;
+
+    // Tömb feltöltése
+    for (int i = 0; i < N_ELEMENTS; i++)
     {
         b[i] = i * 2;
     }
-    for (int i = 0; i; i++)
+
+    // Tömb kiírása
+    for (int i = 0; i < N_ELEMENTS; i++)
     {
-        std::cout << "Ertek:"
-    }    
-    std::cout << "Atlag szamitasa: " << std::endl;
-    int atlag;
-    for (int i = 0; i < N_ELEMENTS, i++)
-    {
-        atlag += b[i]
+        std::cout << "Ertek: " << b[i] << std::endl;
     }
-    atlag /= N_ELEMENTS;
+
+    // Átlag számítása
+    std::cout << "Atlag szamitasa: " << std::endl;
+    int atlag = 0; // Inicializálás
+    for (int i = 0; i < N_ELEMENTS; i++)
+    {
+        atlag += b[i];
+    }
+    atlag /= N_ELEMENTS; // Átlag kiszámítása
     std::cout << "Atlag: " << atlag << std::endl;
+
+    // Memória felszabadítása
+    delete[] b;
+
     return 0;
 }


### PR DESCRIPTION
A constexpr int N_ELEMENTS = 100; jól van definiálva, de a dinamikus tömb deklarációjában (int *b = new int[NELEMENTS];) elírás van: helyesen int *b = new int[N_ELEMENTS];.

A std::cout után egy szimpla idézőjel (') helyett dupla idézőjelet (") kell használni a szöveg kiírására.

Az első for ciklusban (for (int i = 0;)) hiányzik a feltétel és az inkrementálás. Helyesen: for (int i = 0; i < N_ELEMENTS; i++).

A második for ciklusban a feltétel hibás (for (int i = 0; i; i++)). Helyesen: for (int i = 0; i < N_ELEMENTS; i++).

A std::cout-ban hiányzik a kiírandó szöveg és az új sor karakter ("\n" vagy std::endl).

Az atlag változó inicializálása hiányzik. Javítás: int atlag = 0;.

A for ciklusban a feltételnél a vessző (,) helyett pontosvessző (;) szükséges.

Hiányoznak a pontosvesszők (;) a kifejezések végéről.

A program végén a dinamikusan foglalt memóriát fel kell szabadítani.